### PR TITLE
use Alg when available (parse rsa)

### DIFF
--- a/internal/jwk/jwk_parse.go
+++ b/internal/jwk/jwk_parse.go
@@ -76,24 +76,27 @@ func (jwe jwkEntry) parseRSA() (*key, error) {
 		N: &n,
 	}
 
-	/* // there is no alg...
-	switch {
-	case jwe.RsaAlg == "RS256" && len(nbuf) == 256:
+	// First use RsaAlg is we know it
+	// Else determine Alg using N len
+	//
+	// Potential issue found: Gitlab is sending Alg = RS256 but len(nbuf) is 512...
+	//
+	switch jwe.RsaAlg {
+	case "RS256":
 		return &key{pub: &r, hash: crypto.SHA256}, nil
-	case jwe.RsaAlg == "RS384" && len(nbuf) == 384:
+	case "RS384":
 		return &key{pub: &r, hash: crypto.SHA384}, nil
-	case jwe.RsaAlg == "RS512" && len(nbuf) == 512:
+	case "RS512":
 		return &key{pub: &r, hash: crypto.SHA512}, nil
-	}
-	*/
-
-	switch len(nbuf) {
-	case 256:
-		return &key{pub: &r, hash: crypto.SHA256}, nil
-	case 384:
-		return &key{pub: &r, hash: crypto.SHA384}, nil
-	case 512:
-		return &key{pub: &r, hash: crypto.SHA512}, nil
+	default:
+		switch len(nbuf) {
+		case 256:
+			return &key{pub: &r, hash: crypto.SHA256}, nil
+		case 384:
+			return &key{pub: &r, hash: crypto.SHA384}, nil
+		case 512:
+			return &key{pub: &r, hash: crypto.SHA512}, nil
+		}
 	}
 
 	return nil, ErrParse


### PR DESCRIPTION
Address issue #8 

* First check if we have "alg" defined in the jwk
* If yes, we use it
* if not, we try to determine "alg" using the modulus ("n") len